### PR TITLE
Fix issue #7 - TypeError: type of argument cloud_map_options

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -74,8 +74,8 @@ class FrontendService(core.Stack):
             memory_limit_mib=512,
             desired_count=1,
             public_load_balancer=True,
-            cloud_map_options=self.base_platform.sd_namespace,
-            task_image_options=self.fargate_task_image
+            task_image_options=self.fargate_task_image,
+            cloud_map_options=aws_ecs.CloudMapOptions(cloud_map_namespace=self.base_platform.sd_namespace,name='ecsdemo-frontend'),
         )
         
         self.fargate_load_balanced_service.task_definition.add_to_task_role_policy(


### PR DESCRIPTION

Reproduced error
```
Traceback (most recent call last):
  File "app.py", line 354, in <module>
    FrontendService(app, stack_name, env=_env)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/jsii/_runtime.py", line 111, in __call__
    inst = super().__call__(*args, **kwargs)
  File "app.py", line 78, in __init__
    task_image_options=self.fargate_task_image
  File "/home/ec2-user/.local/lib/python3.7/site-packages/jsii/_runtime.py", line 111, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/aws_cdk/aws_ecs_patterns/__init__.py", line 7388, in __init__
    vpc=vpc,
  File "/home/ec2-user/.local/lib/python3.7/site-packages/aws_cdk/aws_ecs_patterns/__init__.py", line 7573, in __init__
    check_type(argname="argument cloud_map_options", value=cloud_map_options, expected_type=type_hints["cloud_map_options"])
  File "/home/ec2-user/.local/lib/python3.7/site-packages/typeguard/__init__.py", line 757, in check_type
    checker_func(argname, value, expected_type, memo)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/typeguard/__init__.py", line 559, in check_union
    format(argname, typelist, qualified_name(value)))
TypeError: type of argument cloud_map_options must be one of (aws_cdk.aws_ecs.CloudMapOptions, Dict[str, Any], NoneType); got jsii._reference_map.InterfaceDynamicProxy instead
```

Test Result 
```
✨  Synthesis time: 14.66s

ecsworkshop-frontend: deploying...
ecsworkshop-frontend: creating CloudFormation changeset...

 ✅  ecsworkshop-frontend

✨  Deployment time: 283.93s

Outputs:
ecsworkshop-frontend.FrontendFargateLBServiceLoadBalancerDNSAFFB8F0B = ecswo-Front-
```