### PR TITLE
fix: wrong code in Service Autoscaling

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -91,7 +91,7 @@ class FrontendService(Stack):
         )
         
         # Enable Service Autoscaling
-        #self.autoscale = fargate_load_balanced_service.service.auto_scale_task_count(
+        #self.autoscale = self.fargate_load_balanced_service.service.auto_scale_task_count(
         #    min_capacity=1,
         #    max_capacity=10
         #)


### PR DESCRIPTION
The service autoscaling does not use `self.fargate_load_balanced_service` which is required.

---
*Description of changes:*
If you just uncomment the code below the comment "Enable Service Autoscaling" it does not work throwing the following error:
```
Traceback (most recent call last):
  File "/home/ec2-user/environment/ecsdemo-frontend/cdk/app.py", line 349, in <module>
    FrontendService(app, stack_name, env=_env)
  File "/home/ec2-user/.local/lib/python3.9/site-packages/jsii/_runtime.py", line 118, in __call__
    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
  File "/home/ec2-user/environment/ecsdemo-frontend/cdk/app.py", line 94, in __init__
    self.autoscale = fargate_load_balanced_service.service.auto_scale_task_count(
NameError: name 'fargate_load_balanced_service' is not defined
```
This is because it does not point to `self.fargate_load_balanced_service.service.auto_scale_task_count`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
